### PR TITLE
Restore dual-camera support on Hailo 1.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,12 @@
-name: Yocto Build Astrial H15 - Hailo 1.12
+name: Astrial H15 Yocto Build and Release
+
+run-name: Astrial H15 Build • ${{ github.ref_name }} • ${{ github.event_name }}
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - porting-hailo-1.12.0
+      - master
   schedule:
     - cron: '0 2 */14 * *'  # Every 2 weeks at 2 AM UTC (only on default branch)
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v1.0.0.${{ github.run_number }}
+          target_commitish: ${{ github.sha }}
           name: Release v1.0.0.${{ github.run_number }}
           body: |
             **Build Information:**

--- a/recipes-kernel/linux/files/arch/arm64/boot/dts/sysele/astrial-h15.dts
+++ b/recipes-kernel/linux/files/arch/arm64/boot/dts/sysele/astrial-h15.dts
@@ -38,6 +38,23 @@
 
 &i2c_1 {
     status = "ok";
+    sensor_0: camera-sensor@1a {
+        status = "ok";
+        compatible = "sony,imx334", "sony,imx675", "sony,imx678", "sony,imx715";
+        reg = <0x1a>;
+        clocks = <&sensor_clk>;
+        clock-names = "inclk";
+        clock-frequency = <24000000>;
+        csi-id = <0>;
+        reset-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+        port {
+            sensor_out_csi2rx0: endpoint {
+                data-lanes = <1 2 3 4>;
+                remote-endpoint = <&csi2rx_in_sensor>;
+                link-frequencies = /bits/ 64 <891000000 1440000000 1782000000>;
+            };
+        };
+    };
     ina231_1v8: 1v8@40 {
         compatible = "ti,ina231_precise";
         reg = <0x40>;
@@ -75,17 +92,17 @@
 		DVDD-supply = <&regulator_1p8v>;
     };
 };
-/*
+
 &csi2rx0 {
     status = "ok";
     ports {
         port@0 {
             csi2rx_in_sensor: endpoint {
-                remote-endpoint = <&sensor_out_csi2rx>;
+                remote-endpoint = <&sensor_out_csi2rx0>;
             };
         };
     };
-};*/
+};
 
 &csi2rx1 {
     status = "ok";

--- a/recipes-kernel/linux/files/arch/arm64/boot/dts/sysele/astrial-h15.dts
+++ b/recipes-kernel/linux/files/arch/arm64/boot/dts/sysele/astrial-h15.dts
@@ -38,7 +38,7 @@
 
 &i2c_1 {
     status = "ok";
-    sensor_0: camera-sensor@1a {
+    sensor_csi0: camera-sensor@1a {
         status = "ok";
         compatible = "sony,imx334", "sony,imx675", "sony,imx678", "sony,imx715";
         reg = <0x1a>;

--- a/recipes-kernel/linux/files/arch/arm64/boot/dts/sysele/astrial-h15.dts
+++ b/recipes-kernel/linux/files/arch/arm64/boot/dts/sysele/astrial-h15.dts
@@ -25,7 +25,6 @@
         clock-names = "inclk";
         clock-frequency = <24000000>;
         csi-id = <1>;
-        reset-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;        
         port {
             sensor_out_csi2rx1: endpoint {
                 data-lanes = <1 2 3 4>;
@@ -46,7 +45,6 @@
         clock-names = "inclk";
         clock-frequency = <24000000>;
         csi-id = <0>;
-        reset-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
         port {
             sensor_out_csi2rx0: endpoint {
                 data-lanes = <1 2 3 4>;
@@ -558,6 +556,20 @@
     gpio-ranges = <&pinctrl 0 16 16>;
 
     gpio-line-names = GPIO_LINE_NAMES;
+
+    /*
+     * CAM0_GPIO0 and CAM1_GPIO0 are physically tied together by
+     * the populated JP15/JP16 jumpers. Keep the shared reset
+     * deasserted so one sensor cannot reset the other during
+     * detection or runtime power management.
+     */
+    camera_reset_hog: camera-reset-hog {
+        gpio-hog;
+        gpios = <1 GPIO_ACTIVE_HIGH>;
+        output-high;
+        line-name = "camera-shared-reset";
+    };
+
 };
 
 &hailo_torrent_phy {

--- a/recipes-media-library/libmedialib/files/0001-resolve-dual-camera-sensors-from-media-graph.patch
+++ b/recipes-media-library/libmedialib/files/0001-resolve-dual-camera-sensors-from-media-graph.patch
@@ -1,0 +1,290 @@
+Subject: [PATCH] libmedialib: resolve dual-camera sensors from media graph
+
+The Astrial H15 camera topology does not associate logical sensor indices
+with I2C bus numbers:
+
+  CSI0 is connected to imx678 1-001a
+  CSI1 is connected to imx678 0-001a
+
+The previous SensorRegistry implementation selected sensor 0 from I2C bus 0
+and sensor 1 from any non-zero bus. This made each ISP/AE instance control the
+sensor connected to the opposite CSI path, causing one image to converge
+towards overexposure and the other towards underexposure.
+
+Resolve the sensor entity connected to cdns_csi2rx_<index> through the Media
+Controller graph and derive the I2C bus, address and V4L2 subdevice from that
+entity.
+
+Add the direct libmediactl Meson dependency.
+
+Upstream-Status: Inappropriate [Astrial H15 board-specific camera topology]
+
+---
+diff --git a/hailo-media-library/media_library/src/isp/sensor_registry/sensor_registry.cpp b/hailo-media-library/media_library/src/isp/sensor_registry/sensor_registry.cpp
+index 9ade243..21a73de 100644
+--- a/hailo-media-library/media_library/src/isp/sensor_registry/sensor_registry.cpp
++++ b/hailo-media-library/media_library/src/isp/sensor_registry/sensor_registry.cpp
+@@ -6,6 +6,12 @@
+ #include <map>
+ #include <set>
+ #include <vector>
++#include <memory>
++
++extern "C"
++{
++#include <mediactl/mediactl.h>
++}
+ 
+ #include "media_library/cloexec_fstream.hpp"
+ #include "media_library_logger.hpp"
+@@ -14,6 +20,150 @@
+ 
+ #define MODULE_NAME LoggerType::Isp
+ 
++namespace
++{
++constexpr const char *MEDIA_DEVICE_PATH = "/dev/media0";
++
++std::optional<std::string> find_subdevice_entity_name(const std::string &prefix)
++{
++    for (const auto &entry : std::filesystem::directory_iterator("/sys/class/video4linux/"))
++    {
++        const std::string filename = entry.path().filename().string();
++        if (!filename.starts_with("v4l-subdev"))
++        {
++            continue;
++        }
++
++        cloexec::ifstream name_file(entry.path() / "name");
++        if (!name_file)
++        {
++            continue;
++        }
++
++        std::string name;
++        std::getline(name_file, name);
++
++        if (name.starts_with(prefix))
++        {
++            return name;
++        }
++    }
++
++    LOGGER__MODULE__ERROR(
++        MODULE_NAME,
++        "Failed to find V4L2 subdevice whose name starts with {}",
++        prefix);
++
++    return std::nullopt;
++}
++
++std::optional<std::pair<std::string, std::string>> get_connected_sensor_entity(size_t sensor_index)
++{
++    const std::string csi_entity_prefix =
++        "cdns_csi2rx_" + std::to_string(sensor_index);
++
++    const auto csi_entity_name =
++        find_subdevice_entity_name(csi_entity_prefix);
++
++    if (!csi_entity_name)
++    {
++        return std::nullopt;
++    }
++
++    using MediaDevicePtr =
++        std::unique_ptr<struct media_device, decltype(&media_device_unref)>;
++
++    MediaDevicePtr media(media_device_new(MEDIA_DEVICE_PATH), &media_device_unref);
++    if (!media)
++    {
++        LOGGER__MODULE__ERROR(
++            MODULE_NAME,
++            "Failed to create media device {}",
++            MEDIA_DEVICE_PATH);
++
++        return std::nullopt;
++    }
++
++    if (media_device_enumerate(media.get()) < 0)
++    {
++        LOGGER__MODULE__ERROR(
++            MODULE_NAME,
++            "Failed to enumerate media device {}",
++            MEDIA_DEVICE_PATH);
++
++        return std::nullopt;
++    }
++
++    struct media_entity *csi_entity =
++        media_get_entity_by_name(media.get(), csi_entity_name->c_str());
++
++    if (!csi_entity)
++    {
++        LOGGER__MODULE__ERROR(
++            MODULE_NAME,
++            "Failed to find media entity {}",
++            *csi_entity_name);
++
++        return std::nullopt;
++    }
++
++    const struct media_pad *sink_pad =
++        media_entity_get_pad(csi_entity, 0);
++
++    if (!sink_pad)
++    {
++        LOGGER__MODULE__ERROR(
++            MODULE_NAME,
++            "Failed to get sink pad 0 for {}",
++            *csi_entity_name);
++
++        return std::nullopt;
++    }
++
++    struct media_pad *remote_source =
++        media_entity_remote_source(
++            const_cast<struct media_pad *>(sink_pad));
++
++    if (!remote_source || !remote_source->entity)
++    {
++        LOGGER__MODULE__ERROR(
++            MODULE_NAME,
++            "No enabled remote source connected to {}",
++            *csi_entity_name);
++
++        return std::nullopt;
++    }
++
++    const struct media_entity_desc *entity_info =
++        media_entity_get_info(remote_source->entity);
++
++    const char *device_path =
++        media_entity_get_devname(remote_source->entity);
++
++    if (!entity_info || !device_path)
++    {
++        LOGGER__MODULE__ERROR(
++            MODULE_NAME,
++            "Failed to resolve sensor entity connected to {}",
++            *csi_entity_name);
++
++        return std::nullopt;
++    }
++
++    LOGGER__MODULE__DEBUG(
++        MODULE_NAME,
++        "Resolved sensor index {} through {} to {} ({})",
++        sensor_index,
++        *csi_entity_name,
++        entity_info->name,
++        device_path);
++
++    return std::pair<std::string, std::string>{
++        entity_info->name,
++        device_path};
++}
++} // namespace
++
+ SensorRegistry::SensorRegistry()
+ {
+     initialize_resolutions();
+@@ -39,39 +189,51 @@ std::optional<SensorCapabilities> SensorRegistry::get_sensor_capabilities(Sensor
+ 
+ std::optional<SensorRegistry::SensorDeviceInfo> SensorRegistry::get_sensor_device_info(size_t sensor_index) const
+ {
+-    for (const auto &entry : std::filesystem::directory_iterator("/sys/class/video4linux/"))
++    auto connected_sensor = get_connected_sensor_entity(sensor_index);
++    if (!connected_sensor)
++    {
++        return std::nullopt;
++    }
++
++    const auto &[name, subdevice_path] = connected_sensor.value();
++
++    for (const auto &[sensor_type, capabilities] : m_sensor_capabilities)
+     {
+-        if (entry.path().filename().string().find("v4l-subdev") != std::string::npos)
++        if (!name.starts_with(capabilities.sub_dev_prefix))
++        {
++            continue;
++        }
++
++        // Parse format: "imx678 0-001a" or "imx678 2-0040"
++        const std::regex bus_regex(capabilities.sub_dev_prefix + "\\s+(\\d+)-(\\w+)");
++        std::smatch matches;
++
++        if (!std::regex_search(name, matches, bus_regex))
+         {
+-            cloexec::ifstream name_file(entry.path() / "name");
+-            std::string name;
+-            std::getline(name_file, name);
+-
+-            for (const auto &[sensor_type, capabilities] : m_sensor_capabilities)
+-            {
+-                if (name.starts_with(capabilities.sub_dev_prefix))
+-                {
+-                    // Parse format: "imx678 0-001a" or "imx678 2-0040"
+-                    std::regex bus_regex(capabilities.sub_dev_prefix + "\\s+(\\d+)-(\\w+)");
+-                    std::smatch matches;
+-
+-                    if (std::regex_search(name, matches, bus_regex))
+-                    {
+-                        int bus = std::stoi(matches[1].str());
+-                        std::string address = matches[2].str();
+-
+-                        // Bus 0 matches sensor 0, bus != 0 matches sensor 1
+-                        if ((sensor_index == 0 && bus == 0) || (sensor_index == 1 && bus != 0))
+-                        {
+-                            std::string subdevice_path = "/dev/" + entry.path().filename().string();
+-                            return SensorDeviceInfo{sensor_type, bus, address, subdevice_path};
+-                        }
+-                    }
+-                }
+-            }
++            continue;
+         }
++
++        const int bus = std::stoi(matches[1].str());
++        const std::string address = matches[2].str();
++
++        LOGGER__MODULE__DEBUG(
++            MODULE_NAME,
++            "Sensor index {} maps to {} on I2C bus {} address {} using {}",
++            sensor_index,
++            name,
++            bus,
++            address,
++            subdevice_path);
++
++        return SensorDeviceInfo{sensor_type, bus, address, subdevice_path};
+     }
+ 
++    LOGGER__MODULE__ERROR(
++        MODULE_NAME,
++        "Unsupported or malformed sensor entity '{}' for sensor index {}",
++        name,
++        sensor_index);
++
+     return std::nullopt;
+ }
+ 
+diff --git a/hailo-media-library/meson.build b/hailo-media-library/meson.build
+index 388d8d9..13a7ea2 100644
+--- a/hailo-media-library/meson.build
++++ b/hailo-media-library/meson.build
+@@ -30,6 +30,7 @@ gstv4l2_dep = dependency('gstvideo4linux2', required: true, include_type: 'syste
+ gstreamer_deps = [gst_dep, gst_base_dep, gstvideo_dep, gst_app_dep, gstallocators_dep, gstv4l2_dep]
+ 
+ libiio_dep = dependency('libiio', version: '>=0.19', required: true)
++libmediactl_dep = dependency('libmediactl', method: 'pkg-config', required: true, include_type: 'system')
+ freetype_dep = dependency('freetype2', method: 'pkg-config', include_type: 'system')
+ harfbuzz_dep = dependency('harfbuzz', method: 'pkg-config', include_type: 'system')
+ rapidjson_dep = dependency('RapidJSON', method : 'pkg-config')
+@@ -61,6 +62,7 @@ medialib_dependencies = [
+     perfetto_dep,
+     rapidjson_dep,
+     libiio_dep,
++    libmediactl_dep,
+     libhailort_dep,
+     freetype_dep,
+     harfbuzz_dep,

--- a/recipes-media-library/libmedialib/files/0001-resolve-dual-camera-sensors-from-media-graph.patch
+++ b/recipes-media-library/libmedialib/files/0001-resolve-dual-camera-sensors-from-media-graph.patch
@@ -34,13 +34,13 @@ index 9ade243..21a73de 100644
 +{
 +#include <mediactl/mediactl.h>
 +}
- 
+
  #include "media_library/cloexec_fstream.hpp"
  #include "media_library_logger.hpp"
 @@ -14,6 +20,150 @@
- 
+
  #define MODULE_NAME LoggerType::Isp
- 
+
 +namespace
 +{
 +constexpr const char *MEDIA_DEVICE_PATH = "/dev/media0";
@@ -189,7 +189,7 @@ index 9ade243..21a73de 100644
  {
      initialize_resolutions();
 @@ -39,39 +189,51 @@ std::optional<SensorCapabilities> SensorRegistry::get_sensor_capabilities(Sensor
- 
+
  std::optional<SensorRegistry::SensorDeviceInfo> SensorRegistry::get_sensor_device_info(size_t sensor_index) const
  {
 -    for (const auto &entry : std::filesystem::directory_iterator("/sys/class/video4linux/"))
@@ -258,7 +258,7 @@ index 9ade243..21a73de 100644
 +
 +        return SensorDeviceInfo{sensor_type, bus, address, subdevice_path};
      }
- 
+
 +    LOGGER__MODULE__ERROR(
 +        MODULE_NAME,
 +        "Unsupported or malformed sensor entity '{}' for sensor index {}",
@@ -267,14 +267,14 @@ index 9ade243..21a73de 100644
 +
      return std::nullopt;
  }
- 
+
 diff --git a/hailo-media-library/meson.build b/hailo-media-library/meson.build
 index 388d8d9..13a7ea2 100644
 --- a/hailo-media-library/meson.build
 +++ b/hailo-media-library/meson.build
 @@ -30,6 +30,7 @@ gstv4l2_dep = dependency('gstvideo4linux2', required: true, include_type: 'syste
  gstreamer_deps = [gst_dep, gst_base_dep, gstvideo_dep, gst_app_dep, gstallocators_dep, gstv4l2_dep]
- 
+
  libiio_dep = dependency('libiio', version: '>=0.19', required: true)
 +libmediactl_dep = dependency('libmediactl', method: 'pkg-config', required: true, include_type: 'system')
  freetype_dep = dependency('freetype2', method: 'pkg-config', include_type: 'system')

--- a/recipes-media-library/libmedialib/libmedialib_%.bbappend
+++ b/recipes-media-library/libmedialib/libmedialib_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://0001-resolve-dual-camera-sensors-from-media-graph.patch \
+"
+
+# libmedialib now uses libmediactl directly to resolve the sensor connected
+# to each CSI receiver from the runtime media graph.
+DEPENDS:append = " v4l-utils"


### PR DESCRIPTION
## Summary

Restore and validate dual-camera support on Astrial H15 with the Hailo 1.12 BSP.

## Changes

- Restore the Astrial H15 dual-camera device-tree configuration.
- Fix the duplicate device-tree label.
- Resolve the physical image sensor through the Media Controller graph instead of assuming that the logical sensor index matches the I2C bus index.
- Keep the shared camera reset line deasserted through a board-level GPIO hog.
- Generalize the GitHub Actions workflow triggers and release naming.
- Tag manual releases at the commit actually used for the build.
- Remove trailing whitespace from the Media Library patch.

## Camera mapping

- Logical SENSOR_0 / CSI0 / `/dev/video0` resolves to the sensor connected through `imx678 1-001a`.
- Logical SENSOR_1 / CSI1 / `/dev/video3` resolves to the sensor connected through `imx678 0-001a`.

The sensor association is obtained from the active Media Controller topology.

## Hardware reset

CAM0 and CAM1 share the same physical reset signal on the Astrial H15 carrier.

The reset is therefore managed as a single board-level GPIO hog and kept high, instead of being independently controlled by the two sensor drivers.

## Validation

Validated using release `v1.0.0.109`:

- Complete Hailo 1.12 Yocto build completed successfully.
- Release artifact generated successfully.
- WIC image flashed to eMMC.
- Automatic dual-camera probe completed successfully.
- Dual-camera application streamed both cameras.
- Cold boot with only CAM0 connected:
  - automatic probe completed successfully;
  - single-camera stream completed successfully.
- Cold boot with only CAM1 connected:
  - automatic probe completed successfully;
  - single-camera stream completed successfully.

Direct RAW/V4L2 acquisition without the Hailo Media Library is outside the scope of this change.
