### PR TITLE
ci: fix reusable build permissions (dev-build/bump erano invalidi)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-large-runner
-    permissions:
-      contents: write
+    # I permessi NON si dichiarano qui: un reusable non può chiedere più di quanto
+    # il chiamante gli concede (altrimenti "Invalid workflow file"). Li decide chi
+    # chiama: main=write (release), dev-build/bump=read. Vedi `permissions:` nei chiamanti.
     env:
       # Radice della cache Yocto, fuori da meta-hailo-soc/build (che NON si cacha).
       # Deve combaciare con ${TOPDIR}/../../yocto-cache usato in kas/astrial-h15-cache.yml.


### PR DESCRIPTION
Il job di build.yml dichiarava 'permissions: contents: write'. Un reusable workflow non puo' richiedere piu' permessi di quanti il chiamante gli concede, quindi dev-build.yml e la validazione del bump (che concedono 'contents: read') fallivano con 'Invalid workflow file ... requesting contents: write, but is only allowed contents: read'.

Fix: rimosso il blocco permissions dal reusable -> eredita dal chiamante (main=write per la release, dev-build/bump=read). La release non era impattata (main concede write). Nessun'altra modifica.